### PR TITLE
#110 [fix] 버튼 터치영역 수정 및 웹사이트 연결

### DIFF
--- a/app/src/main/java/com/sopetit/softie/ui/main/home/HomeFragment.kt
+++ b/app/src/main/java/com/sopetit/softie/ui/main/home/HomeFragment.kt
@@ -1,6 +1,7 @@
 package com.sopetit.softie.ui.main.home
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
@@ -63,6 +64,7 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
         setClickBear()
         setClickDaily()
         setClickHappy()
+        moveToPaymentView()
     }
 
     private fun setClickSetting() {
@@ -88,6 +90,14 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
     private fun setClickHappy() {
         binding.clHomeSomColor.setOnClickListener {
             checkCottonRemain(Cotton.HAPPINESS)
+        }
+    }
+
+    private fun moveToPaymentView() {
+        binding.ivHomeMoney.setOnClickListener {
+            startActivity(
+                Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.my_page_policy_link)))
+            )
         }
     }
 

--- a/app/src/main/java/com/sopetit/softie/ui/setting/SettingInitFragment.kt
+++ b/app/src/main/java/com/sopetit/softie/ui/setting/SettingInitFragment.kt
@@ -1,6 +1,7 @@
 package com.sopetit.softie.ui.setting
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.ViewModelProvider
@@ -8,7 +9,6 @@ import com.sopetit.softie.R
 import com.sopetit.softie.databinding.FragmentSettingInitBinding
 import com.sopetit.softie.ui.login.LoginActivity
 import com.sopetit.softie.ui.setting.SettingActivity.Companion.USER_EXIT
-import com.sopetit.softie.ui.setting.SettingActivity.Companion.USER_SECURITY
 import com.sopetit.softie.util.OriginalBottomSheet.Companion.BOTTOM_SHEET_TAG
 import com.sopetit.softie.util.binding.BindingBottomSheet
 import com.sopetit.softie.util.binding.BindingFragment
@@ -32,24 +32,55 @@ class SettingInitFragment :
         clickUserSecurity()
         clickLogOut()
         clickUserExit()
+        clickUserSecurity()
+        clickDocument()
+        clickGuide()
+        clickFeedback()
     }
 
     private fun clickUserSecurity() {
         binding.clSettingInitUserSecurity.setOnClickListener {
-            viewModel.setSettingFragment(USER_SECURITY)
+            startActivity(
+                Intent(
+                    Intent.ACTION_VIEW,
+                    Uri.parse(getString(R.string.setting_user_security_link))
+                )
+            )
         }
     }
 
     private fun clickDocument() {
         // TODO 서비스 이용 약관
+        binding.clSettingInitDocument.setOnClickListener {
+            startActivity(
+                Intent(
+                    Intent.ACTION_VIEW,
+                    Uri.parse(getString(R.string.setting_service_document_link))
+                )
+            )
+        }
     }
 
     private fun clickGuide() {
-        // TODO 서비스 이용 가이드
+        binding.clSettingInitGuide.setOnClickListener {
+            startActivity(
+                Intent(
+                    Intent.ACTION_VIEW,
+                    Uri.parse(getString(R.string.setting_service_guide_link))
+                )
+            )
+        }
     }
 
     private fun clickFeedback() {
-        // TODO 피드백
+        binding.clSettingInitFeedback.setOnClickListener {
+            startActivity(
+                Intent(
+                    Intent.ACTION_VIEW,
+                    Uri.parse(getString(R.string.setting_feedback_link))
+                )
+            )
+        }
     }
 
     private fun clickLogOut() {

--- a/app/src/main/res/layout/activity_daily_routine_add.xml
+++ b/app/src/main/res/layout/activity_daily_routine_add.xml
@@ -24,7 +24,9 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="18dp"
             android:layout_marginTop="16dp"
-            android:background="@drawable/ic_daily_back"
+            android:scaleType="centerCrop"
+            android:padding="7dp"
+            android:src="@drawable/ic_daily_back"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/layout/activity_happy_add_detail.xml
+++ b/app/src/main/res/layout/activity_happy_add_detail.xml
@@ -21,7 +21,8 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="18dp"
             android:layout_marginTop="16dp"
-            android:background="@drawable/ic_back_arrow"
+            android:padding="7dp"
+            android:src="@drawable/ic_back_arrow"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/layout/activity_happy_add_list.xml
+++ b/app/src/main/res/layout/activity_happy_add_list.xml
@@ -19,6 +19,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="18dp"
             android:layout_marginTop="16dp"
+            android:padding="7dp"
             android:src="@drawable/ic_back_arrow"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -23,7 +23,7 @@
             android:background="@android:color/transparent"
             android:layout_marginStart="18dp"
             android:layout_marginTop="16dp"
-            android:padding="5dp"
+            android:padding="7dp"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
 

--- a/app/src/main/res/layout/fragment_daily_routine.xml
+++ b/app/src/main/res/layout/fragment_daily_routine.xml
@@ -63,13 +63,14 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_daily_routine_name">
 
-            <ImageButton
+            <ImageView
                 android:id="@+id/btn_daily_routine_radio_first"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:layout_marginEnd="21dp"
-                android:background="@drawable/selector_daily_edit"
+                android:layout_marginTop="13dp"
+                android:layout_marginEnd="14dp"
+                android:padding="7dp"
+                android:src="@drawable/selector_daily_edit"
                 android:visibility="@{viewModel.isDeleteView ? View.VISIBLE: View.INVISIBLE}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -165,13 +166,14 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/cl_daily_routine_first">
 
-            <ImageButton
+            <ImageView
                 android:id="@+id/btn_daily_routine_radio_second"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:layout_marginEnd="21dp"
-                android:background="@drawable/selector_daily_edit"
+                android:layout_marginTop="13dp"
+                android:layout_marginEnd="14dp"
+                android:padding="7dp"
+                android:src="@drawable/selector_daily_edit"
                 android:visibility="@{viewModel.isDeleteView ? View.VISIBLE: View.INVISIBLE}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -262,12 +264,13 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/cl_daily_routine_second">
 
-            <ImageButton
+            <ImageView
                 android:id="@+id/btn_daily_routine_radio_third"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:layout_marginEnd="21dp"
+                android:layout_marginTop="13dp"
+                android:layout_marginEnd="14dp"
+                android:padding="7dp"
                 android:background="@drawable/selector_daily_edit"
                 android:visibility="@{viewModel.isDeleteView ? View.VISIBLE: View.INVISIBLE}"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -41,8 +41,9 @@
             android:id="@+id/iv_home_setting"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:layout_marginEnd="22dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginEnd="15dp"
+            android:padding="7dp"
             android:src="@drawable/ic_home_settings"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -51,8 +52,9 @@
             android:id="@+id/iv_home_money"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:layout_marginEnd="8dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginEnd="6dp"
+            android:padding="7dp"
             android:src="@drawable/ic_home_money"
             app:layout_constraintEnd_toStartOf="@id/iv_home_setting"
             app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,6 +110,11 @@
     <string name="user_logout_content">“잠시만 안녕.. 다음에 또 봐!”</string>
     <string name="user_logout_back">취소</string>
     <string name="user_logout_exit">로그아웃 할래</string>
+    <string name="setting_user_security_link">https://softie-link.notion.site/c2435b30cfdb45db82f91cae6d1cc789</string>
+    <string name="setting_service_document_link">https://softie-link.notion.site/b8b8c02805924f2ababd4de7b2306d64?pvs=4</string>
+    <string name="setting_service_guide_link">https://softie-link.notion.site/6a65faa32923410a84ff6a63c47cf752</string>
+    <string name="setting_feedback_link">https://docs.google.com/forms/d/e/1FAIpQLSfEtF_qWDu9mI1IcEBPTWsoBVCwPa0wunQK600EcjOMbz8upQ/viewform</string>
+
 
     <!-- bottom sheet -->
     <string name="bottom_sheet_title">정말 로그아웃할까요?</string>
@@ -148,6 +153,7 @@
     <string name="home_happiness_cotton_btn">행복 솜뭉치 주기</string>
     <string name="home_daily_cotton_btn">솜뭉치 주기</string>
     <string name="splash_service_introduce">친구와 함께 하는 일상 속 작은 습관</string>
+    <string name="my_page_policy_link">https://softie-link.notion.site/92fc58e36cf448eca66ee47e1c50bee8</string>
 
     <!-- daily routine add -->
     <string name="daily_routine_add_question">데일리 루틴을 추가할까요?</string>


### PR DESCRIPTION
## 📑 Work Description
- 데일리루틴 추가하기 뷰, 설정뷰, 행복 루틴 추가하기(목록)뷰, 행복 루틴 추가하기 (상세)뷰 뒤로가기 버튼 터치영역 확장했습니다.
- 루틴 편집시 나오는 라디오 버튼, 홈뷰에 있는 커머스, 설정 터치 영역 확장했습니다.
- 모든 웹사이트 연결 했습니다.

## 🛠️ Issue
- closed #110 

## 📷 Screenshot

https://github.com/Team-Sopetit/Sopetit-Android/assets/145532333/a19c827b-4336-484c-92c0-d0e4a1618483



## 💬 To Reviewers
다 확인하긴 했는데 호옥시 자기 뷰가 빠진거 같다면 얘기해주세요,,!