### PR TITLE
#151 [qa] 데일리 루틴 2차 qa 이슈 해결

### DIFF
--- a/app/src/main/java/com/sopetit/softie/ui/dailyroutine/dailyroutineadd/DailyRoutineAddThemeAdapter.kt
+++ b/app/src/main/java/com/sopetit/softie/ui/dailyroutine/dailyroutineadd/DailyRoutineAddThemeAdapter.kt
@@ -9,7 +9,7 @@ import com.sopetit.softie.R
 import com.sopetit.softie.databinding.ItemDailyRoutineAddThemeBinding
 import com.sopetit.softie.domain.entity.Theme
 import com.sopetit.softie.util.ItemDiffCallback
-import com.sopetit.softie.util.binding.BindingAdapter.setBaseCoilImage
+import com.sopetit.softie.util.binding.BindingAdapter.setCoilImage
 import com.sopetit.softie.util.setSingleOnClickListener
 
 class DailyRoutineAddThemeAdapter :
@@ -38,7 +38,7 @@ class DailyRoutineAddThemeAdapter :
         RecyclerView.ViewHolder(binding.root) {
         fun onBind(data: Theme) {
             binding.tvDailyRoutineAddThemeName.text = data.name
-            binding.ivDailyRoutineAddThemeIcon.setBaseCoilImage(data.iconImageUrl)
+            binding.ivDailyRoutineAddThemeIcon.setCoilImage(data.iconImageUrl)
             if (selectedPosition == absoluteAdapterPosition) {
                 changeThemeBackground(binding, true)
                 changeThemeTextColor(binding, true)

--- a/app/src/main/java/com/sopetit/softie/util/binding/BindingAdapter.kt
+++ b/app/src/main/java/com/sopetit/softie/util/binding/BindingAdapter.kt
@@ -5,7 +5,6 @@ import androidx.databinding.BindingAdapter
 import coil.decode.SvgDecoder
 import coil.load
 import com.bumptech.glide.Glide
-import com.sopetit.softie.R
 
 object BindingAdapter {
     @BindingAdapter("setImage")
@@ -25,21 +24,6 @@ object BindingAdapter {
                     decoderFactory { result, options, _ -> SvgDecoder(result.source, options) }
                 }
                 crossfade(true)
-            }
-        }
-    }
-
-    @BindingAdapter("setBaseCoilImage")
-    @JvmStatic
-    fun ImageView.setBaseCoilImage(imgUrl: String?) {
-        this.let {
-            it.load(imgUrl) {
-                if (imgUrl?.endsWith(".svg") == true) {
-                    decoderFactory { result, options, _ -> SvgDecoder(result.source, options) }
-                }
-                crossfade(true)
-                placeholder(R.drawable.ic_loading_bear)
-                error(R.drawable.ic_loading_bear)
             }
         }
     }

--- a/app/src/main/res/layout/fragment_daily_routine.xml
+++ b/app/src/main/res/layout/fragment_daily_routine.xml
@@ -268,7 +268,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="13dp"
                 android:layout_marginEnd="14dp"
-                android:background="@drawable/selector_daily_edit"
+                android:src="@drawable/selector_daily_edit"
                 android:padding="7dp"
                 android:visibility="@{viewModel.isDeleteView ? View.VISIBLE: View.INVISIBLE}"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/item_daily_routine_add_card.xml
+++ b/app/src/main/res/layout/item_daily_routine_add_card.xml
@@ -1,44 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-    <data>
+    <ImageView
+        android:id="@+id/tv_daily_routine_add_card"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"
+        android:scaleType="centerCrop"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="0.7"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <variable
-            name="data"
-            type="com.sopetit.softie.domain.entity.Theme" />
-    </data>
+    <TextView
+        android:id="@+id/tv_daily_routine_add_card_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="44dp"
+        android:layout_marginTop="84dp"
+        android:gravity="center"
+        android:lineSpacingExtra="4dp"
+        android:text="@string/daily_routine_add_card_name"
+        android:textAppearance="@style/head1"
+        app:layout_constraintEnd_toEndOf="@id/tv_daily_routine_add_card"
+        app:layout_constraintStart_toStartOf="@id/tv_daily_routine_add_card"
+        app:layout_constraintTop_toTopOf="@id/tv_daily_routine_add_card" />
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <ImageView
-            android:id="@+id/tv_daily_routine_add_card"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:adjustViewBounds="true"
-            android:scaleType="centerCrop"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintDimensionRatio="0.7"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:id="@+id/tv_daily_routine_add_card_name"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="44dp"
-            android:layout_marginTop="84dp"
-            android:gravity="center"
-            android:lineSpacingExtra="4dp"
-            android:text="@string/daily_routine_add_card_name"
-            android:textAppearance="@style/head1"
-            app:layout_constraintEnd_toEndOf="@id/tv_daily_routine_add_card"
-            app:layout_constraintStart_toStartOf="@id/tv_daily_routine_add_card"
-            app:layout_constraintTop_toTopOf="@id/tv_daily_routine_add_card" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-</layout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_daily_routine_add_card.xml
+++ b/app/src/main/res/layout/item_daily_routine_add_card.xml
@@ -1,34 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <ImageView
-        android:id="@+id/tv_daily_routine_add_card"
-        android:layout_width="280dp"
-        android:layout_height="398dp"
-        android:layout_marginVertical="65dp"
-        android:scaleType="centerCrop"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintDimensionRatio="0.7"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <data>
 
-    <TextView
-        android:id="@+id/tv_daily_routine_add_card_name"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="84dp"
-        android:layout_marginHorizontal="44dp"
-        android:gravity="center"
-        android:lineSpacingExtra="4dp"
-        android:text="@string/daily_routine_add_card_name"
-        android:textAppearance="@style/head1"
-        app:layout_constraintEnd_toEndOf="@id/tv_daily_routine_add_card"
-        app:layout_constraintStart_toStartOf="@id/tv_daily_routine_add_card"
-        app:layout_constraintTop_toTopOf="@id/tv_daily_routine_add_card" />
+        <variable
+            name="data"
+            type="com.sopetit.softie.domain.entity.Theme" />
+    </data>
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <ImageView
+            android:id="@+id/tv_daily_routine_add_card"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:adjustViewBounds="true"
+            android:scaleType="centerCrop"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="0.7"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_daily_routine_add_card_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="44dp"
+            android:layout_marginTop="84dp"
+            android:gravity="center"
+            android:lineSpacingExtra="4dp"
+            android:text="@string/daily_routine_add_card_name"
+            android:textAppearance="@style/head1"
+            app:layout_constraintEnd_toEndOf="@id/tv_daily_routine_add_card"
+            app:layout_constraintStart_toStartOf="@id/tv_daily_routine_add_card"
+            app:layout_constraintTop_toTopOf="@id/tv_daily_routine_add_card" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/item_daily_routine_add_theme.xml
+++ b/app/src/main/res/layout/item_daily_routine_add_theme.xml
@@ -41,7 +41,6 @@
                 android:layout_width="30dp"
                 android:layout_height="30dp"
                 android:layout_gravity="center"
-                app:setBaseCoilImage="@{data.iconImageUrl}"
                 app:layout_constraintBottom_toBottomOf="@id/iv_daily_routine_add_theme_background"
                 app:layout_constraintEnd_toEndOf="@id/iv_daily_routine_add_theme_background"
                 app:layout_constraintStart_toStartOf="@id/iv_daily_routine_add_theme_background"


### PR DESCRIPTION
## 📑 Work Description
- 세번째 라디오 버튼 위치 수정했습니다. 
- 카드 고정 dp -> 0dp, wrap_content로 변경했습니다.
- 데일리 루틴 테마 부분 기본이미지 삭제했습니다.

## 🛠️ Issue
- closed #151 

## 📷 Screenshot

에뮬 젤 긴거

https://github.com/Team-Sopetit/Sopetit-Android/assets/145532333/ec254985-0dd0-417f-8591-8c13b6239745

플립

https://github.com/Team-Sopetit/Sopetit-Android/assets/145532333/28f64d27-66e3-4e5f-95cd-cdd336475220


## 💬 To Reviewers
1) 데일리 루틴 카드 짤림 이슈
지민이 폰이 일단 길어서 에뮬 제일 긴거랑 플립으로 확인해줬을 땐, 카드가 다 괜찮게 나왔습니다..!

2) 데일리 루틴 테마 로딩 느림 이슈
데일리 루틴 테마 부분은 svg로 오는거라 setcoilimage를 사용했던 거고 카드뷰는 기본 load 사용해도 잘 받아와지는 걸 보니 svg로 오는게 아니었던 것 같습니다. 둘의 차이점은 setcolimage를 쓰냐 load를 쓰냐 인데, 기본이미지를 넣었을 때, 카드뷰만 로딩 속도가 그대로고 테마는 겁나 느려지는 걸 보니 svg에 기본 이미지를 넣어주면 로딩이 훨씬 느리게 되는 것이 아닌가.. 추측입니다.. 

그래서 테마는 원래 로딩이 별로 느리지 않았어서 그대로 가도 되지 않을까ㅎ.ㅎ 싶어 일단 원래대로 돌려놨습니다. 확인 부탁드립니다..

3) 루틴 안나옴 이슈
로그 찍어보니 모든 루틴 다 잘 나와서 아마 qa 진행하면서 해당 루틴을 추가시켜놔서 없어진 것 같습니다. 일단 노션엔 남겨놨습니다 !