### PR TITLE
#171 [hotfix] 데일리 루틴 테마 리스트 조회할 때, 기본값을 고정으로 전달해서 테마 리스트가 변동할 경우 순서 안맞는 이슈 해결

### DIFF
--- a/app/src/main/java/com/sopetit/softie/ui/dailyroutine/dailyroutineadd/DailyRoutineAddActivity.kt
+++ b/app/src/main/java/com/sopetit/softie/ui/dailyroutine/dailyroutineadd/DailyRoutineAddActivity.kt
@@ -37,8 +37,8 @@ class DailyRoutineAddActivity :
         setStatusBarColorFromResource(R.color.background)
 
         dailyRoutineAddViewModel.getThemeList()
-        dailyRoutineAddViewModel.themeList.observe(this){list ->
-            if(list.isNotEmpty()){
+        dailyRoutineAddViewModel.themeList.observe(this) { list ->
+            if (list.isNotEmpty()) {
                 dailyRoutineAddViewModel.setThemeId(list[0].themeId)
             }
         }

--- a/app/src/main/java/com/sopetit/softie/ui/dailyroutine/dailyroutineadd/DailyRoutineAddActivity.kt
+++ b/app/src/main/java/com/sopetit/softie/ui/dailyroutine/dailyroutineadd/DailyRoutineAddActivity.kt
@@ -37,7 +37,11 @@ class DailyRoutineAddActivity :
         setStatusBarColorFromResource(R.color.background)
 
         dailyRoutineAddViewModel.getThemeList()
-        dailyRoutineAddViewModel.setThemeId(6)
+        dailyRoutineAddViewModel.themeList.observe(this){list ->
+            if(list.isNotEmpty()){
+                dailyRoutineAddViewModel.setThemeId(list[0].themeId)
+            }
+        }
         setupAdapter()
         setupList()
         setIndicator()

--- a/app/src/main/java/com/sopetit/softie/ui/dailyroutine/dailyroutineadd/DailyRoutineAddViewModel.kt
+++ b/app/src/main/java/com/sopetit/softie/ui/dailyroutine/dailyroutineadd/DailyRoutineAddViewModel.kt
@@ -71,7 +71,7 @@ class DailyRoutineAddViewModel @Inject constructor(
 
     fun getDailyRoutine() {
         viewModelScope.launch {
-            getRoutineDailyThemeListUseCase(themeId.value ?: 6)
+            getRoutineDailyThemeListUseCase(themeId.value ?: _themeList.value?.get(0)?.themeId ?: 5)
                 .onSuccess { response ->
                     _dailyRoutineCardThemeList.value = response
                 }


### PR DESCRIPTION
## 📑 Work Description
- 데일리 루틴 테마 리스트 조회할 때, 기본값을 고정으로 전달해서 테마 리스트가 변동할 경우 순서 안맞는 이슈 해결

## 🛠️ Issue
- closed #171 

## 📷 Screenshot

https://github.com/Team-Sopetit/Sopetit-Android/assets/91793891/e957e644-0bfd-417d-850c-6e8090d0f9c9

## 💬 To Reviewers
- 하드 코딩의 문제입니다..!